### PR TITLE
fix: expose DyteWebRTC library target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     platforms: [.iOS(.v13)],
     products: [
         .library(name: packageName, targets: [packageName, "DyteWebRTC"]),
+        .library(name: "DyteWebRTC", targets: ["DyteWebRTC"]),
     ],
     targets: [
         .binaryTarget(
@@ -26,4 +27,3 @@ let package = Package(
         ),
     ]
 )
-


### PR DESCRIPTION
This is necessary to be able to use this from Swift Package Manager since as of now it is only published to Cocoapods.